### PR TITLE
allow passing a property filter to the tooltip

### DIFF
--- a/packages/map-tooltip/README.md
+++ b/packages/map-tooltip/README.md
@@ -2,8 +2,26 @@
 
 ## Documentation
 ### Props
-- tileLayers (Array): array of ids (currently osm and any eox id)
-. showCenter (Boolean): show center coordinates
+- propertiesFilter (Array): filter displayed properties, expects an array like this: 
+```
+[
+  {
+    field_name: "ori_parcel_id",
+    display_name: "SL_ID",
+    type: "string"
+  },
+  {
+    field_name: "colour",
+    display_name: "Conformance",
+    type: "legend/color"
+  },
+  {
+    field_name: "ori_crop_id",
+    display_name: "SNAR_CODE",
+    type: "reference/crop"
+  }
+],
+```
 
 ## Install
 

--- a/packages/map-tooltip/src/MapToolTip.vue
+++ b/packages/map-tooltip/src/MapToolTip.vue
@@ -6,7 +6,7 @@
           v-for="(property, index) in tooltipContent"
           :key="index"
         >
-          {{ index }}: {{ property }}
+          {{ property.display_name }}: {{ property.value }}
         </li>
       </ul>
     </v-tooltip>
@@ -21,6 +21,7 @@ export default {
   props: {
     mapObject: Object,
     hoverFeature: Object,
+    propertiesFilter: Array,
   },
   components: {
     VTooltip,
@@ -45,7 +46,20 @@ export default {
   watch: {
     hoverFeature(element) {
       if (element) {
-        this.tooltipContent = element.feature.properties_;
+        this.tooltipContent = Object.keys(element.feature.properties_)
+          .map((p) => ({
+            field_name: p,
+            display_name: p,
+            value: element.feature.properties_[p],
+          }));
+        if (this.propertiesFilter) {
+          this.tooltipContent = this.propertiesFilter
+            .map((p) => ({
+              field_name: p.field_name,
+              display_name: p.display_name,
+              value: element.feature.properties_[p.field_name],
+            }));
+        }
         this.overlay.setPosition(element.coordinate);
       }
     },


### PR DESCRIPTION
probably needs some docs.

`:propertiesFilter` expects an array like this: 
```
[
  {
    field_name: "ori_parcel_id",
    display_name: "SL_ID",
    type: "string"
  },
  {
    field_name: "colour",
    display_name: "Conformance",
    type: "legend/color"
  },
  {
    field_name: "ori_crop_id",
    display_name: "SNAR_CODE",
    type: "reference/crop"
  }
],
```