### PR TITLE
fix(WIP): build local iframe using remote assets

### DIFF
--- a/elements/chart/src/interface.ts
+++ b/elements/chart/src/interface.ts
@@ -1,3 +1,5 @@
+import pkg from "../package.json";
+
 const channel = new MessageChannel();
 const port1 = channel.port1;
 
@@ -62,15 +64,13 @@ const createChart = (div: HTMLElement | null) => {
     iframe.setAttribute("id", "EOxChart");
     div?.appendChild(iframe);
     if (!import.meta?.url?.includes("localhost")) {
-      fetch("https://www.unpkg.com/@eox/chart/dist/index.html")
+      const hostUrl = `https://www.unpkg.com/@eox/chart@${pkg.version}/dist`;
+      fetch(`${hostUrl}/index.html`)
         .then((response) => {
           return response.text();
         })
         .then((text) => {
-          const html = text.replace(
-            "./assets/",
-            "https://www.unpkg.com/@eox/chart/dist/assets/"
-          );
+          const html = text.replace("./assets/", `${hostUrl}/assets/`);
           iframe.contentDocument?.open();
           iframe.contentDocument?.write(html);
           iframe.contentDocument?.close();

--- a/elements/chart/src/interface.ts
+++ b/elements/chart/src/interface.ts
@@ -63,15 +63,18 @@ const createChart = (div: HTMLElement | null) => {
     div?.appendChild(iframe);
     if (!import.meta?.url?.includes("localhost")) {
       fetch("https://www.unpkg.com/@eox/chart/dist/index.html")
-      .then((response) => {
-        return response.text();
-      })
-      .then((text) => {
-        const html = text.replace('./assets/', 'https://www.unpkg.com/@eox/chart/dist/assets/');
-        iframe.contentDocument?.open();
-        iframe.contentDocument?.write(html);
-        iframe.contentDocument?.close();
-      })
+        .then((response) => {
+          return response.text();
+        })
+        .then((text) => {
+          const html = text.replace(
+            "./assets/",
+            "https://www.unpkg.com/@eox/chart/dist/assets/"
+          );
+          iframe.contentDocument?.open();
+          iframe.contentDocument?.write(html);
+          iframe.contentDocument?.close();
+        });
     }
     let iframeLoaded = false;
     iframe.onload = () => {

--- a/elements/chart/src/interface.ts
+++ b/elements/chart/src/interface.ts
@@ -62,12 +62,12 @@ const createChart = (div: HTMLElement | null) => {
     iframe.setAttribute("id", "EOxChart");
     div?.appendChild(iframe);
     if (!import.meta?.url?.includes("localhost")) {
-      fetch("https://raw.githack.com/EOX-A/elements/chartelement/elements/chart/dist/index.html")
+      fetch("https://www.unpkg.com/@eox/chart/dist/index.html")
       .then((response) => {
         return response.text();
       })
       .then((text) => {
-        const html = text.replace('./assets/', 'https://raw.githack.com/EOX-A/elements/chartelement/elements/chart/dist/assets/');
+        const html = text.replace('./assets/', 'https://www.unpkg.com/@eox/chart/dist/assets/');
         iframe.contentDocument?.open();
         iframe.contentDocument?.write(html);
         iframe.contentDocument?.close();

--- a/elements/chart/src/interface.ts
+++ b/elements/chart/src/interface.ts
@@ -57,10 +57,22 @@ const createChart = (div: HTMLElement | null) => {
       "src",
       import.meta?.url?.includes("localhost")
         ? "http://localhost:5173/index.html"
-        : "https://www.unpkg.com/@eox/chart/dist/index.html"
+        : "about:blank"
     );
     iframe.setAttribute("id", "EOxChart");
     div?.appendChild(iframe);
+    if (!import.meta?.url?.includes("localhost")) {
+      fetch("https://raw.githack.com/EOX-A/elements/chartelement/elements/chart/dist/index.html")
+      .then((response) => {
+        return response.text();
+      })
+      .then((text) => {
+        const html = text.replace('./assets/', 'https://raw.githack.com/EOX-A/elements/chartelement/elements/chart/dist/assets/');
+        iframe.contentDocument?.open();
+        iframe.contentDocument?.write(html);
+        iframe.contentDocument?.close();
+      })
+    }
     let iframeLoaded = false;
     iframe.onload = () => {
       // store if the iFrame has already loaded, since in Cypress hovering over the test triggers


### PR DESCRIPTION
This PR changes the way the iframe is created, instead of having an iframe that points to the hosting location, the iframe is crated locally and the hosted HTML is parsed and used as iframe content. This allows the iframe to run locally and use the same origin/referer/cookies as the host application and prevents CORS/authentication errors.

The host has also been changed from `unpkg` to `githack`.

not sure if this is the cleanest way to do this, and how configurable we want to make this.