### PR TITLE
Map/draw

### DIFF
--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -39,9 +39,9 @@ export class EOxMap extends HTMLElement {
 
   /**
    * removes a given draw interaction from the map. Layer have to be removed seperately
-   * @param drawId id of a vector layer to draw on
+   * @param id id of the interaction
   */
-  removeDraw: Function;
+  removeInteraction: Function;
 
 
 
@@ -90,8 +90,9 @@ export class EOxMap extends HTMLElement {
       addDraw(this, layerId, options);
     };
 
-    this.removeDraw = (id: string) => {
+    this.removeInteraction = (id: string) => {
       this.map.removeInteraction(this.interactions[id])
+      delete this.interactions[id];
     };
 
     this.map.on("loadend", () => {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -7,6 +7,7 @@ import { apply } from "ol-mapbox-style";
 
 import olCss from "ol/ol.css";
 import { addDraw } from "./src/draw";
+import Interaction from "ol/interaction/Interaction";
 
 export class EOxMap extends HTMLElement {
   private shadow: ShadowRoot;
@@ -18,11 +19,31 @@ export class EOxMap extends HTMLElement {
   map: Map;
 
   /**
+   * dictionary of ol interactions associated with the map.
+   */
+  interactions: {[index: string]: Interaction}
+
+  /**
    * Apply layers from Mapbox Style JSON
    * @param json a Mapbox Style JSON
    * @returns the array of layers
-   */
+  */
   setLayers: Function;
+
+  /**
+   * Adds draw functionality to a given vector layer.
+   * @param layerId id of a vector layer to draw on
+   * @returns id of draw interaction
+  */
+  addDraw: Function;
+
+  /**
+   * removes a given draw interaction from the map. Layer have to be removed seperately
+   * @param drawId id of a vector layer to draw on
+  */
+  removeDraw: Function;
+
+
 
   constructor() {
     super();
@@ -59,10 +80,18 @@ export class EOxMap extends HTMLElement {
           : 0,
       }),
     });
+    this.interactions = {};
 
     this.setLayers = (json: JSON) => {
       apply(this.map, json);
-      addDraw(this.map, json);
+    };
+
+    this.addDraw = (layerId: string, options: Object) => {
+      addDraw(this, layerId, options);
+    };
+
+    this.removeDraw = (id: string) => {
+      this.map.removeInteraction(this.interactions[id])
     };
 
     this.map.on("loadend", () => {

--- a/elements/map/main.ts
+++ b/elements/map/main.ts
@@ -6,6 +6,7 @@ import { Coordinate } from "ol/coordinate";
 import { apply } from "ol-mapbox-style";
 
 import olCss from "ol/ol.css";
+import { addDraw } from "./src/draw";
 
 export class EOxMap extends HTMLElement {
   private shadow: ShadowRoot;
@@ -61,6 +62,7 @@ export class EOxMap extends HTMLElement {
 
     this.setLayers = (json: JSON) => {
       apply(this.map, json);
+      addDraw(this.map, json);
     };
 
     this.map.on("loadend", () => {

--- a/elements/map/package.json
+++ b/elements/map/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@eox/eslint-config": "^1.0.0",
+    "@types/mapbox-gl": "^2.7.11",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "eslint-plugin-typescript": "^0.14.0",

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -15,9 +15,13 @@ export function addDraw(
   
   const map = EOxMap.map;
 
-  const drawLayer = map.getLayers().getArray()
-    .filter(l => l.get('mapbox-layers'))
-    .find(l => l.get('mapbox-layers').includes(layerId));
+  // get mapbox-style layer or manually generated ol layer
+  let drawLayer = map.getLayers()
+      .getArray()
+      .find(l => l.get('id') === layerId) ||
+    map.getLayers().getArray()
+      .filter(l => l.get('mapbox-layers'))
+      .find(l => l.get('mapbox-layers').includes(layerId));
 
     if (!drawLayer) {
       throw Error(`Layer with id: ${layerId} does not exist.`);

--- a/elements/map/src/draw.ts
+++ b/elements/map/src/draw.ts
@@ -1,0 +1,33 @@
+import Map from 'ol/Map.js';
+import Draw from 'ol/interaction/Draw.js';
+import {MapboxLayer} from './types';
+import { getSource } from 'ol-mapbox-style';
+import VectorSource from 'ol/source/Vector';
+
+export function addDraw(
+  map: Map,
+  styleJson: any
+): void {
+  
+  const sourceKeys = Object.keys(styleJson.sources)
+  sourceKeys.forEach(sourceKey => {
+    const mapboxLayers: [MapboxLayer] = styleJson.layers;
+    const drawLayer = mapboxLayers.find(l => l.source === sourceKey)
+
+    if (drawLayer) {
+      const drawDefinition = drawLayer.metadata.draw
+      const source = getSource(map, sourceKey) as VectorSource;
+
+      if (drawDefinition) {
+        const drawInteraction = new Draw({
+          type: drawDefinition.type,
+          source
+        });
+        // identifier to retrieve the interaction
+        drawInteraction.set('id', `draw_${sourceKey}`)
+        map.addInteraction(drawInteraction);
+      }
+    }
+  })
+  
+}

--- a/elements/map/src/types.ts
+++ b/elements/map/src/types.ts
@@ -1,0 +1,6 @@
+import {
+  AnyLayer,
+  CustomLayerInterface
+} from 'mapbox-gl';
+
+export type MapboxLayer = Exclude<AnyLayer, CustomLayerInterface>;

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -1,23 +1,39 @@
+import VectorLayer from "ol/layer/Vector";
 import { EOxMap } from "../main";
 import vectorLayerStyleJson from "./drawInteraction.json";
+import { simulateEvent } from "./utils/events";
+import VectorSource from "ol/source/Vector";
+import { Point } from "ol/geom";
+
 
 describe("draw interaction", () => {
   beforeEach(() => {
     cy.visit("/elements/map/test/general.html");
   });
-  it("loads a Vector Layer", () => {
+  it("adds a draw interaction", () => {
     cy.get("eox-map").should(($el) => {
-      const eoxMap = <EOxMap>$el[0];
+    const eoxMap = <EOxMap>$el[0];
+  
       eoxMap.setLayers(vectorLayerStyleJson);
-      eoxMap.addDraw('draw_layer', {
+      eoxMap.addDraw('draw_point', {
         id: 'drawInteraction',
-        type: 'LineString',
+        type: 'Point',
       });
 
       // get the interaction via the source key
       const drawInteraction = eoxMap.interactions['drawInteraction']
       expect(drawInteraction).to.exist; 
       expect(drawInteraction.getActive()).to.equal(true)
+      
+
+      simulateEvent(eoxMap.map, 'pointermove', 10, 20);
+      simulateEvent(eoxMap.map, 'pointerdown', 10, 20);
+      simulateEvent(eoxMap.map, 'pointerup', 10, 20);
+      const drawLayer = eoxMap.map.getLayers().getArray()[1] as VectorLayer<VectorSource>;
+      const features = drawLayer.getSource().getFeatures();
+      const geometry = features[0].getGeometry() as Point;
+      expect(geometry.getCoordinates().length).to.be.equal(2);
     });
   });
 });
+

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -1,0 +1,19 @@
+import { EOxMap } from "../main";
+import vectorLayerStyleJson from "./drawInteraction.json";
+
+describe("draw interaction", () => {
+  beforeEach(() => {
+    cy.visit("/elements/map/test/general.html");
+  });
+  it("loads a Vector Layer", () => {
+    cy.get("eox-map").should(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.setLayers(vectorLayerStyleJson);
+      const interactions = eoxMap.map.getInteractions();
+      // get the interaction via the source key
+      const drawInteraction = interactions.getArray().find(i => i.get('id') === 'draw_draw_layer');
+      expect(drawInteraction).to.exist;
+      expect(drawInteraction.getActive()).to.equal(true)
+    });
+  });
+});

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -9,30 +9,42 @@ import { Point } from "ol/geom";
 describe("draw interaction", () => {
   beforeEach(() => {
     cy.visit("/elements/map/test/general.html");
-  });
-  it("adds a draw interaction", () => {
     cy.get("eox-map").should(($el) => {
-    const eoxMap = <EOxMap>$el[0];
-  
+      const eoxMap = <EOxMap>$el[0];
       eoxMap.setLayers(vectorLayerStyleJson);
       eoxMap.addDraw('draw_point', {
         id: 'drawInteraction',
         type: 'Point',
       });
-
+    })
+  });
+  it("adds a draw interaction", () => {
+    cy.get("eox-map").should(($el) => {
+      const eoxMap = <EOxMap>$el[0];
       // get the interaction via the source key
       const drawInteraction = eoxMap.interactions['drawInteraction']
       expect(drawInteraction).to.exist; 
       expect(drawInteraction.getActive()).to.equal(true)
-      
+    });
+  });
 
-      simulateEvent(eoxMap.map, 'pointermove', 10, 20);
+  it("creates correct geometry", () => {
+    cy.get("eox-map").should(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      console.log(eoxMap);
       simulateEvent(eoxMap.map, 'pointerdown', 10, 20);
       simulateEvent(eoxMap.map, 'pointerup', 10, 20);
       const drawLayer = eoxMap.map.getLayers().getArray()[1] as VectorLayer<VectorSource>;
       const features = drawLayer.getSource().getFeatures();
       const geometry = features[0].getGeometry() as Point;
       expect(geometry.getCoordinates().length).to.be.equal(2);
+    });
+  });
+
+  it("remove interaction", () => {
+    cy.get("eox-map").should(($el) => {
+      const eoxMap = <EOxMap>$el[0];
+      eoxMap.map.removeInteraction(eoxMap.interactions['drawInteraction'])
     });
   });
 });

--- a/elements/map/test/drawInteraction.cy.ts
+++ b/elements/map/test/drawInteraction.cy.ts
@@ -9,10 +9,14 @@ describe("draw interaction", () => {
     cy.get("eox-map").should(($el) => {
       const eoxMap = <EOxMap>$el[0];
       eoxMap.setLayers(vectorLayerStyleJson);
-      const interactions = eoxMap.map.getInteractions();
+      eoxMap.addDraw('draw_layer', {
+        id: 'drawInteraction',
+        type: 'LineString',
+      });
+
       // get the interaction via the source key
-      const drawInteraction = interactions.getArray().find(i => i.get('id') === 'draw_draw_layer');
-      expect(drawInteraction).to.exist;
+      const drawInteraction = eoxMap.interactions['drawInteraction']
+      expect(drawInteraction).to.exist; 
       expect(drawInteraction.getActive()).to.equal(true)
     });
   });

--- a/elements/map/test/drawInteraction.json
+++ b/elements/map/test/drawInteraction.json
@@ -15,13 +15,6 @@
       "id": "draw_layer",
       "type": "line",
       "source": "draw_layer",
-      "metadata": {
-        "group": "draw_layer",
-        "draw": {
-          "active": true,
-          "type": "LineString"
-        }
-      },
       "paint": {
         "line-color": "blue",
         "fill-color": "rgba(255,255,255,0.4)",

--- a/elements/map/test/drawInteraction.json
+++ b/elements/map/test/drawInteraction.json
@@ -1,0 +1,32 @@
+{
+  "version": 8,
+  "name": "",
+  "sources": {
+    "draw_layer": {
+      "type": "geojson",
+      "data": {
+        "type": "FeatureCollection",
+        "features": []
+      }
+    }
+  },
+  "layers": [
+    {
+      "id": "draw_layer",
+      "type": "line",
+      "source": "draw_layer",
+      "metadata": {
+        "group": "draw_layer",
+        "draw": {
+          "active": true,
+          "type": "LineString"
+        }
+      },
+      "paint": {
+        "line-color": "blue",
+        "fill-color": "rgba(255,255,255,0.4)",
+        "line-width": 2
+      }
+    }
+  ]
+}

--- a/elements/map/test/drawInteraction.json
+++ b/elements/map/test/drawInteraction.json
@@ -13,11 +13,10 @@
   "layers": [
     {
       "id": "draw_line",
-      "type": "LineString",
+      "type": "line",
       "source": "draw_layer",
       "paint": {
         "line-color": "blue",
-        "fill-color": "rgba(255,255,255,0.4)",
         "line-width": 2
       }
     },

--- a/elements/map/test/drawInteraction.json
+++ b/elements/map/test/drawInteraction.json
@@ -12,13 +12,24 @@
   },
   "layers": [
     {
-      "id": "draw_layer",
-      "type": "line",
+      "id": "draw_line",
+      "type": "LineString",
       "source": "draw_layer",
       "paint": {
         "line-color": "blue",
         "fill-color": "rgba(255,255,255,0.4)",
         "line-width": 2
+      }
+    },
+    {
+      "id": "draw_point",
+      "source": "draw_layer",
+      "type": "circle",
+      "paint": {
+        "circle-radius": 10,
+        "circle-color": "red",
+        "circle-stroke-color": "#ffffff",
+        "circle-stroke-width": 3
       }
     }
   ]

--- a/elements/map/test/utils/events.ts
+++ b/elements/map/test/utils/events.ts
@@ -1,0 +1,22 @@
+import { Map, MapBrowserEvent } from "ol";
+
+const width = 400;
+const height = 400;
+/**
+   * Simulates a browser event on the map viewport.
+   */
+export function simulateEvent(map: Map, type: 'pointermove'|'pointerup'|'pointerdown', x: number, y: number) {
+  const viewport = map.getViewport();
+  // calculated in case body has top < 0 (test runner with small window)
+  const position = viewport.getBoundingClientRect();
+  const event = {} as any;
+  event.type = type;
+  event.target = viewport.firstChild;
+  event.clientX = position.left + x + width / 2;
+  event.clientY = position.top + y + height / 2;
+  event.preventDefault = function () {};
+  event.pointerType = 'mouse';
+  const simulatedEvent = new MapBrowserEvent(type, map, event);
+  map.handleMapBrowserEvent(simulatedEvent);
+  return simulatedEvent;
+}


### PR DESCRIPTION
This PR introduces the draw functionality, which can be used as a blueprint for other ol interactions.

The draw interaction expects an existing vector layer. 

References to all interactions are stored in an `EoxMap.interactions` dictionary and can get disabled or otherwise adapted via it's native functionality. Removal of this and future interactions are to be done via `EoxMap.removeInteraction`.